### PR TITLE
ROP no longer fails to load on add reg to rsp/esp

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -912,7 +912,12 @@ class ROP:
                     regs.append(pop.match(insn).group(1))
                     sp_move += self.align
                 elif add.match(insn):
-                    sp_move += int(add.match(insn).group(1), 16)
+                    # This throws a value error when it comes across something
+                    # like `add esp, eax` so catch that
+                    try:
+                        sp_move += int(add.match(insn).group(1), 16)
+                    except ValueError:
+                        pass
                 elif ret.match(insn):
                     sp_move += self.align
                 elif leave.match(insn):


### PR DESCRIPTION
ROP.__load takes any gadgets that add to esp and converts the amount
they add to esp to an int. However this threw an exception on finding
the instruction `add esp, eax` because eax is not an int.

Signed-off-by: John Andersen johnandersenpdx@gmail.com
